### PR TITLE
企業一覧のテーブルビュー対応

### DIFF
--- a/app/companies/page.tsx
+++ b/app/companies/page.tsx
@@ -1,13 +1,31 @@
 "use client";
 
-import { Suspense } from "react";
+import { Suspense, useState, useMemo } from "react";
 import { useSearchParams } from "next/navigation";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import { CompanyCard } from "@/components/CompanyCard";
+import { CompanyTable } from "@/components/CompanyTable";
 import { useCompanies } from "@/hooks/useCompany";
 import { STATUS_CONFIG, CompanyStatus } from "@/lib/constants";
-import { Building2, RefreshCw, Loader2 } from "lucide-react";
+import { Company } from "@/types";
+import {
+  Building2,
+  RefreshCw,
+  Loader2,
+  LayoutGrid,
+  List,
+  Search,
+  ChevronLeft,
+  ChevronRight,
+} from "lucide-react";
+
+type ViewMode = "card" | "table";
+type SortField = "name" | "ai_score" | "status" | "created_at";
+type SortOrder = "asc" | "desc";
+
+const ITEMS_PER_PAGE_OPTIONS = [20, 50, 100];
 
 function CompaniesContent() {
   const searchParams = useSearchParams();
@@ -15,13 +33,112 @@ function CompaniesContent() {
 
   const { companies, loading, refetch } = useCompanies(status || undefined);
 
+  // View mode
+  const [viewMode, setViewMode] = useState<ViewMode>("card");
+
+  // Search
+  const [searchQuery, setSearchQuery] = useState("");
+
+  // Status filter (separate from URL param)
+  const [statusFilter, setStatusFilter] = useState<CompanyStatus | "all">("all");
+
+  // Sort
+  const [sortField, setSortField] = useState<SortField>("created_at");
+  const [sortOrder, setSortOrder] = useState<SortOrder>("desc");
+
+  // Pagination
+  const [currentPage, setCurrentPage] = useState(1);
+  const [itemsPerPage, setItemsPerPage] = useState(20);
+
   const config = status ? STATUS_CONFIG[status] : null;
   const Icon = config?.icon || Building2;
   const title = config?.label || "全企業";
   const description = config?.description || "登録されているすべての企業";
 
+  // Filter and sort companies
+  const filteredAndSortedCompanies = useMemo(() => {
+    let result = [...companies];
+
+    // Status filter
+    if (statusFilter !== "all") {
+      result = result.filter((company) => company.status === statusFilter);
+    }
+
+    // Search filter
+    if (searchQuery) {
+      const query = searchQuery.toLowerCase();
+      result = result.filter(
+        (company) =>
+          company.name.toLowerCase().includes(query) ||
+          company.address?.toLowerCase().includes(query) ||
+          company.phone?.includes(query)
+      );
+    }
+
+    // Sort
+    result.sort((a, b) => {
+      let comparison = 0;
+
+      switch (sortField) {
+        case "name":
+          comparison = a.name.localeCompare(b.name, "ja");
+          break;
+        case "ai_score":
+          const scoreA = a.ai_score ?? -1;
+          const scoreB = b.ai_score ?? -1;
+          comparison = scoreA - scoreB;
+          break;
+        case "status":
+          const statusOrder = { pending: 0, scraped: 1, emailed: 2 };
+          comparison = statusOrder[a.status] - statusOrder[b.status];
+          break;
+        case "created_at":
+          comparison =
+            new Date(a.created_at).getTime() - new Date(b.created_at).getTime();
+          break;
+      }
+
+      return sortOrder === "asc" ? comparison : -comparison;
+    });
+
+    return result;
+  }, [companies, statusFilter, searchQuery, sortField, sortOrder]);
+
+  // Pagination
+  const totalPages = Math.ceil(filteredAndSortedCompanies.length / itemsPerPage);
+  const paginatedCompanies = useMemo(() => {
+    const start = (currentPage - 1) * itemsPerPage;
+    return filteredAndSortedCompanies.slice(start, start + itemsPerPage);
+  }, [filteredAndSortedCompanies, currentPage, itemsPerPage]);
+
+  // Reset to page 1 when filters change
+  const handleSearchChange = (value: string) => {
+    setSearchQuery(value);
+    setCurrentPage(1);
+  };
+
+  const handleStatusFilterChange = (value: CompanyStatus | "all") => {
+    setStatusFilter(value);
+    setCurrentPage(1);
+  };
+
+  const handleItemsPerPageChange = (value: number) => {
+    setItemsPerPage(value);
+    setCurrentPage(1);
+  };
+
+  const handleSort = (field: SortField) => {
+    if (sortField === field) {
+      setSortOrder(sortOrder === "asc" ? "desc" : "asc");
+    } else {
+      setSortField(field);
+      setSortOrder("desc");
+    }
+  };
+
   return (
     <div className="space-y-6">
+      {/* Header */}
       <div className="flex items-center justify-between">
         <div>
           <h1 className="text-3xl font-bold flex items-center gap-2">
@@ -36,10 +153,84 @@ function CompaniesContent() {
         </Button>
       </div>
 
-      <div className="text-sm text-muted-foreground">
-        {companies.length} 件の企業
+      {/* Controls */}
+      <div className="flex flex-col sm:flex-row gap-4 items-start sm:items-center justify-between">
+        {/* Search and Status Filter */}
+        <div className="flex flex-col sm:flex-row gap-2 w-full sm:w-auto">
+          <div className="relative w-full sm:w-64">
+            <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+            <Input
+              placeholder="企業名・住所で検索..."
+              value={searchQuery}
+              onChange={(e) => handleSearchChange(e.target.value)}
+              className="pl-9"
+            />
+          </div>
+          {/* Status Filter - only show when not filtered by URL */}
+          {!status && (
+            <select
+              value={statusFilter}
+              onChange={(e) =>
+                handleStatusFilterChange(e.target.value as CompanyStatus | "all")
+              }
+              className="h-9 rounded-md border border-input bg-background px-3 text-sm"
+            >
+              <option value="all">すべてのステータス</option>
+              <option value="pending">{STATUS_CONFIG.pending.label}</option>
+              <option value="scraped">{STATUS_CONFIG.scraped.label}</option>
+              <option value="emailed">{STATUS_CONFIG.emailed.label}</option>
+            </select>
+          )}
+        </div>
+
+        <div className="flex items-center gap-4">
+          {/* Items per page */}
+          <div className="flex items-center gap-2">
+            <span className="text-sm text-muted-foreground">表示:</span>
+            <select
+              value={itemsPerPage}
+              onChange={(e) => handleItemsPerPageChange(Number(e.target.value))}
+              className="h-9 rounded-md border border-input bg-background px-3 text-sm"
+            >
+              {ITEMS_PER_PAGE_OPTIONS.map((option) => (
+                <option key={option} value={option}>
+                  {option}件
+                </option>
+              ))}
+            </select>
+          </div>
+
+          {/* View mode toggle */}
+          <div className="flex items-center border rounded-md">
+            <Button
+              variant={viewMode === "card" ? "secondary" : "ghost"}
+              size="sm"
+              onClick={() => setViewMode("card")}
+              className="rounded-r-none"
+            >
+              <LayoutGrid className="h-4 w-4" />
+            </Button>
+            <Button
+              variant={viewMode === "table" ? "secondary" : "ghost"}
+              size="sm"
+              onClick={() => setViewMode("table")}
+              className="rounded-l-none"
+            >
+              <List className="h-4 w-4" />
+            </Button>
+          </div>
+        </div>
       </div>
 
+      {/* Count */}
+      <div className="text-sm text-muted-foreground">
+        {filteredAndSortedCompanies.length} 件
+        {searchQuery && ` (検索結果)`}
+        {filteredAndSortedCompanies.length !== companies.length &&
+          ` / 全 ${companies.length} 件`}
+      </div>
+
+      {/* Content */}
       {loading ? (
         <Card>
           <CardContent className="py-12 text-center">
@@ -47,21 +238,94 @@ function CompaniesContent() {
             <p className="text-muted-foreground">読み込み中...</p>
           </CardContent>
         </Card>
-      ) : companies.length > 0 ? (
-        <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-4">
-          {companies.map((company) => (
-            <CompanyCard
-              key={company.id}
-              company={company}
-              showAnalysis={company.ai_score !== null}
+      ) : paginatedCompanies.length > 0 ? (
+        <>
+          {viewMode === "card" ? (
+            <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-4">
+              {paginatedCompanies.map((company) => (
+                <CompanyCard
+                  key={company.id}
+                  company={company}
+                  showAnalysis={company.ai_score !== null}
+                />
+              ))}
+            </div>
+          ) : (
+            <CompanyTable
+              companies={paginatedCompanies}
+              sortField={sortField}
+              sortOrder={sortOrder}
+              onSort={handleSort}
             />
-          ))}
-        </div>
+          )}
+
+          {/* Pagination */}
+          {totalPages > 1 && (
+            <div className="flex items-center justify-between pt-4">
+              <div className="text-sm text-muted-foreground">
+                {(currentPage - 1) * itemsPerPage + 1} -{" "}
+                {Math.min(currentPage * itemsPerPage, filteredAndSortedCompanies.length)}{" "}
+                / {filteredAndSortedCompanies.length} 件
+              </div>
+              <div className="flex items-center gap-2">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setCurrentPage((p) => Math.max(1, p - 1))}
+                  disabled={currentPage === 1}
+                >
+                  <ChevronLeft className="h-4 w-4" />
+                </Button>
+                <div className="flex items-center gap-1">
+                  {Array.from({ length: totalPages }, (_, i) => i + 1)
+                    .filter((page) => {
+                      // Show first, last, and pages around current
+                      return (
+                        page === 1 ||
+                        page === totalPages ||
+                        Math.abs(page - currentPage) <= 1
+                      );
+                    })
+                    .map((page, index, array) => {
+                      // Add ellipsis
+                      const prev = array[index - 1];
+                      const showEllipsis = prev && page - prev > 1;
+                      return (
+                        <span key={page} className="flex items-center">
+                          {showEllipsis && (
+                            <span className="px-2 text-muted-foreground">...</span>
+                          )}
+                          <Button
+                            variant={currentPage === page ? "default" : "outline"}
+                            size="sm"
+                            onClick={() => setCurrentPage(page)}
+                            className="w-9"
+                          >
+                            {page}
+                          </Button>
+                        </span>
+                      );
+                    })}
+                </div>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setCurrentPage((p) => Math.min(totalPages, p + 1))}
+                  disabled={currentPage === totalPages}
+                >
+                  <ChevronRight className="h-4 w-4" />
+                </Button>
+              </div>
+            </div>
+          )}
+        </>
       ) : (
         <Card>
           <CardContent className="py-12 text-center">
             <Icon className="h-12 w-12 mx-auto text-muted-foreground mb-4" />
-            <p className="text-muted-foreground">該当する企業がありません</p>
+            <p className="text-muted-foreground">
+              {searchQuery ? "検索条件に該当する企業がありません" : "該当する企業がありません"}
+            </p>
           </CardContent>
         </Card>
       )}

--- a/components/CompanyTable.tsx
+++ b/components/CompanyTable.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+import Link from "next/link";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Company } from "@/types";
+import { STATUS_CONFIG, getScoreVariant } from "@/lib/constants";
+import { ArrowUpDown, ExternalLink, Eye } from "lucide-react";
+
+type SortField = "name" | "ai_score" | "status" | "created_at";
+type SortOrder = "asc" | "desc";
+
+interface CompanyTableProps {
+  companies: Company[];
+  sortField: SortField;
+  sortOrder: SortOrder;
+  onSort: (field: SortField) => void;
+}
+
+export function CompanyTable({
+  companies,
+  sortField,
+  sortOrder,
+  onSort,
+}: CompanyTableProps) {
+  const SortButton = ({
+    field,
+    children,
+  }: {
+    field: SortField;
+    children: React.ReactNode;
+  }) => (
+    <Button
+      variant="ghost"
+      size="sm"
+      className="-ml-3 h-8 data-[state=active]:bg-accent"
+      onClick={() => onSort(field)}
+      data-state={sortField === field ? "active" : undefined}
+    >
+      {children}
+      <ArrowUpDown className="ml-2 h-4 w-4" />
+      {sortField === field && (
+        <span className="ml-1 text-xs">{sortOrder === "asc" ? "↑" : "↓"}</span>
+      )}
+    </Button>
+  );
+
+  return (
+    <div className="rounded-md border">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead className="w-[250px]">
+              <SortButton field="name">企業名</SortButton>
+            </TableHead>
+            <TableHead className="hidden md:table-cell">住所</TableHead>
+            <TableHead className="hidden lg:table-cell">電話番号</TableHead>
+            <TableHead>
+              <SortButton field="ai_score">スコア</SortButton>
+            </TableHead>
+            <TableHead>
+              <SortButton field="status">ステータス</SortButton>
+            </TableHead>
+            <TableHead className="hidden sm:table-cell">HP</TableHead>
+            <TableHead className="w-[80px]">操作</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {companies.length === 0 ? (
+            <TableRow>
+              <TableCell colSpan={7} className="h-24 text-center">
+                該当する企業がありません
+              </TableCell>
+            </TableRow>
+          ) : (
+            companies.map((company) => {
+              const statusConfig = STATUS_CONFIG[company.status];
+              return (
+                <TableRow key={company.id}>
+                  <TableCell className="font-medium">
+                    <span className="line-clamp-1">{company.name}</span>
+                  </TableCell>
+                  <TableCell className="hidden md:table-cell">
+                    <span className="line-clamp-1 text-sm text-muted-foreground">
+                      {company.address || "-"}
+                    </span>
+                  </TableCell>
+                  <TableCell className="hidden lg:table-cell">
+                    <span className="text-sm text-muted-foreground">
+                      {company.phone || "-"}
+                    </span>
+                  </TableCell>
+                  <TableCell>
+                    {company.ai_score !== null ? (
+                      <Badge variant={getScoreVariant(company.ai_score)}>
+                        {company.ai_score}
+                      </Badge>
+                    ) : (
+                      <span className="text-sm text-muted-foreground">-</span>
+                    )}
+                  </TableCell>
+                  <TableCell>
+                    <Badge variant={statusConfig.badgeVariant}>
+                      {statusConfig.label}
+                    </Badge>
+                  </TableCell>
+                  <TableCell className="hidden sm:table-cell">
+                    {company.website ? (
+                      <a
+                        href={company.website}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-primary hover:underline inline-flex items-center gap-1"
+                      >
+                        <ExternalLink className="h-4 w-4" />
+                      </a>
+                    ) : (
+                      <span className="text-sm text-muted-foreground">-</span>
+                    )}
+                  </TableCell>
+                  <TableCell>
+                    <Link href={`/details/${company.id}`}>
+                      <Button variant="ghost" size="sm">
+                        <Eye className="h-4 w-4" />
+                      </Button>
+                    </Link>
+                  </TableCell>
+                </TableRow>
+              );
+            })
+          )}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}

--- a/components/ui/table.tsx
+++ b/components/ui/table.tsx
@@ -1,0 +1,119 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+const Table = React.forwardRef<
+  HTMLTableElement,
+  React.HTMLAttributes<HTMLTableElement>
+>(({ className, ...props }, ref) => (
+  <div className="relative w-full overflow-auto">
+    <table
+      ref={ref}
+      className={cn("w-full caption-bottom text-sm", className)}
+      {...props}
+    />
+  </div>
+));
+Table.displayName = "Table";
+
+const TableHeader = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <thead ref={ref} className={cn("[&_tr]:border-b", className)} {...props} />
+));
+TableHeader.displayName = "TableHeader";
+
+const TableBody = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <tbody
+    ref={ref}
+    className={cn("[&_tr:last-child]:border-0", className)}
+    {...props}
+  />
+));
+TableBody.displayName = "TableBody";
+
+const TableFooter = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <tfoot
+    ref={ref}
+    className={cn(
+      "border-t bg-muted/50 font-medium [&>tr]:last:border-b-0",
+      className
+    )}
+    {...props}
+  />
+));
+TableFooter.displayName = "TableFooter";
+
+const TableRow = React.forwardRef<
+  HTMLTableRowElement,
+  React.HTMLAttributes<HTMLTableRowElement>
+>(({ className, ...props }, ref) => (
+  <tr
+    ref={ref}
+    className={cn(
+      "border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted",
+      className
+    )}
+    {...props}
+  />
+));
+TableRow.displayName = "TableRow";
+
+const TableHead = React.forwardRef<
+  HTMLTableCellElement,
+  React.ThHTMLAttributes<HTMLTableCellElement>
+>(({ className, ...props }, ref) => (
+  <th
+    ref={ref}
+    className={cn(
+      "h-10 px-2 text-left align-middle font-medium text-muted-foreground [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+      className
+    )}
+    {...props}
+  />
+));
+TableHead.displayName = "TableHead";
+
+const TableCell = React.forwardRef<
+  HTMLTableCellElement,
+  React.TdHTMLAttributes<HTMLTableCellElement>
+>(({ className, ...props }, ref) => (
+  <td
+    ref={ref}
+    className={cn(
+      "p-2 align-middle [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+      className
+    )}
+    {...props}
+  />
+));
+TableCell.displayName = "TableCell";
+
+const TableCaption = React.forwardRef<
+  HTMLTableCaptionElement,
+  React.HTMLAttributes<HTMLTableCaptionElement>
+>(({ className, ...props }, ref) => (
+  <caption
+    ref={ref}
+    className={cn("mt-4 text-sm text-muted-foreground", className)}
+    {...props}
+  />
+));
+TableCaption.displayName = "TableCaption";
+
+export {
+  Table,
+  TableHeader,
+  TableBody,
+  TableFooter,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableCaption,
+};


### PR DESCRIPTION
## Summary
- 企業一覧画面にテーブルビューを追加
- カード/テーブル表示の切り替え機能
- ページネーション（20/50/100件表示）
- キーワード検索・ステータスフィルター・ソート機能

## Test plan
- [ ] http://localhost:3000/companies でテーブル/カード切り替えを確認
- [ ] ページネーションの動作確認
- [ ] 検索・フィルター・ソートの動作確認

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)