### PR TITLE
feat: AI分析スコアリングロジックの改善 (#8)

### DIFF
--- a/app/api/scrape/route.ts
+++ b/app/api/scrape/route.ts
@@ -63,6 +63,8 @@ export async function POST(request: NextRequest) {
       .update({
         ai_score: analysisData.analysis.score,
         ai_reason: analysisData.analysis.reason,
+        partner_score: analysisData.analysis.partnerScore,
+        company_type: analysisData.analysis.companyType,
         status: "scraped",
         updated_at: new Date().toISOString(),
       })

--- a/app/details/[id]/page.tsx
+++ b/app/details/[id]/page.tsx
@@ -98,6 +98,8 @@ export default function CompanyDetailsPage() {
     company.ai_score !== null
       ? {
           score: company.ai_score,
+          partnerScore: company.partner_score ?? 0,
+          companyType: company.company_type ?? "unknown",
           reason: company.ai_reason || "",
           manualWorkPotential: scrapedData?.manual_work_potential || "不明",
           recommendedApproach: "詳細はHP情報を取得してください",
@@ -130,13 +132,24 @@ export default function CompanyDetailsPage() {
                 <Building2 className="h-6 w-6" />
                 {company.name}
               </CardTitle>
-              <div className="flex gap-2 mt-2">
+              <div className="flex gap-2 mt-2 flex-wrap">
                 <Badge variant={statusConfig.badgeVariant}>
                   {statusConfig.label}
                 </Badge>
+                {company.company_type && (
+                  <Badge variant={company.company_type === "partner" ? "default" : "secondary"}>
+                    {company.company_type === "outsource" ? "外注検討企業" :
+                     company.company_type === "partner" ? "パートナー候補" : "未分類"}
+                  </Badge>
+                )}
                 {company.ai_score !== null && (
                   <Badge variant={getScoreVariant(company.ai_score)}>
-                    スコア: {company.ai_score}
+                    外注ニーズ: {company.ai_score}
+                  </Badge>
+                )}
+                {company.partner_score !== null && (
+                  <Badge variant={getScoreVariant(company.partner_score)}>
+                    パートナー: {company.partner_score}
                   </Badge>
                 )}
               </div>

--- a/components/AnalysisResult.tsx
+++ b/components/AnalysisResult.tsx
@@ -31,17 +31,26 @@ export function AnalysisResult({ result }: AnalysisResultProps) {
         </CardTitle>
       </CardHeader>
       <CardContent className="space-y-4">
-        <div className="flex items-center gap-4">
+        <div className="flex items-start gap-4 flex-wrap">
           <div
-            className={`px-6 py-3 rounded-lg ${getScoreBg(result.score)} text-center`}
+            className={`px-6 py-3 rounded-lg ${getScoreBg(result.score)} text-center min-w-[100px]`}
           >
-            <p className="text-xs text-muted-foreground mb-1">スコア</p>
+            <p className="text-xs text-muted-foreground mb-1">外注ニーズ</p>
             <p className={`text-3xl font-bold ${getScoreColor(result.score)}`}>
               {result.score}
               <span className="text-sm text-muted-foreground">/100</span>
             </p>
           </div>
-          <div className="flex-1">
+          <div
+            className={`px-6 py-3 rounded-lg ${getScoreBg(result.partnerScore)} text-center min-w-[100px]`}
+          >
+            <p className="text-xs text-muted-foreground mb-1">パートナー</p>
+            <p className={`text-3xl font-bold ${getScoreColor(result.partnerScore)}`}>
+              {result.partnerScore}
+              <span className="text-sm text-muted-foreground">/100</span>
+            </p>
+          </div>
+          <div className="flex-1 min-w-[200px]">
             <p className="text-sm font-medium flex items-center gap-2 mb-1">
               <Target className="h-4 w-4" />
               判定理由

--- a/components/CompanyCard.tsx
+++ b/components/CompanyCard.tsx
@@ -36,9 +36,20 @@ export function CompanyCard({ company, showAnalysis = false }: CompanyCardProps)
           <Badge variant={statusConfig.badgeVariant} className="whitespace-nowrap">
             {statusConfig.label}
           </Badge>
+          {showAnalysis && company.company_type && (
+            <Badge variant={company.company_type === "partner" ? "default" : "secondary"} className="whitespace-nowrap">
+              {company.company_type === "outsource" ? "外注検討" :
+               company.company_type === "partner" ? "パートナー" : "未分類"}
+            </Badge>
+          )}
           {showAnalysis && company.ai_score !== null && (
             <Badge variant={getScoreVariant(company.ai_score)} className="whitespace-nowrap">
-              スコア: {company.ai_score}
+              外注: {company.ai_score}
+            </Badge>
+          )}
+          {showAnalysis && company.partner_score !== null && (
+            <Badge variant={getScoreVariant(company.partner_score)} className="whitespace-nowrap">
+              パートナー: {company.partner_score}
             </Badge>
           )}
         </div>

--- a/components/CompanyTable.tsx
+++ b/components/CompanyTable.tsx
@@ -63,9 +63,11 @@ export function CompanyTable({
             </TableHead>
             <TableHead className="hidden md:table-cell">住所</TableHead>
             <TableHead className="hidden lg:table-cell">電話番号</TableHead>
+            <TableHead className="hidden sm:table-cell">タイプ</TableHead>
             <TableHead>
-              <SortButton field="ai_score">スコア</SortButton>
+              <SortButton field="ai_score">外注</SortButton>
             </TableHead>
+            <TableHead className="hidden sm:table-cell">パートナー</TableHead>
             <TableHead>
               <SortButton field="status">ステータス</SortButton>
             </TableHead>
@@ -78,7 +80,7 @@ export function CompanyTable({
         <TableBody>
           {companies.length === 0 ? (
             <TableRow>
-              <TableCell colSpan={9} className="h-24 text-center">
+              <TableCell colSpan={11} className="h-24 text-center">
                 該当する企業がありません
               </TableCell>
             </TableRow>
@@ -100,10 +102,29 @@ export function CompanyTable({
                       {company.phone || "-"}
                     </span>
                   </TableCell>
+                  <TableCell className="hidden sm:table-cell">
+                    {company.company_type ? (
+                      <Badge variant={company.company_type === "partner" ? "default" : "secondary"}>
+                        {company.company_type === "outsource" ? "外注検討" :
+                         company.company_type === "partner" ? "パートナー" : "未分類"}
+                      </Badge>
+                    ) : (
+                      <span className="text-sm text-muted-foreground">-</span>
+                    )}
+                  </TableCell>
                   <TableCell>
                     {company.ai_score !== null ? (
                       <Badge variant={getScoreVariant(company.ai_score)}>
                         {company.ai_score}
+                      </Badge>
+                    ) : (
+                      <span className="text-sm text-muted-foreground">-</span>
+                    )}
+                  </TableCell>
+                  <TableCell className="hidden sm:table-cell">
+                    {company.partner_score !== null ? (
+                      <Badge variant={getScoreVariant(company.partner_score)}>
+                        {company.partner_score}
                       </Badge>
                     ) : (
                       <span className="text-sm text-muted-foreground">-</span>

--- a/lib/claude.ts
+++ b/lib/claude.ts
@@ -8,6 +8,8 @@ const DEFAULT_EMAIL: GeneratedEmail = {
 
 const DEFAULT_ANALYSIS: AnalysisResult = {
   score: 50,
+  partnerScore: 50,
+  companyType: "unknown",
   reason: "分析に失敗しました",
   manualWorkPotential: "不明",
   recommendedApproach: "直接お問い合わせください",
@@ -63,7 +65,7 @@ export async function analyzeCompanyWithContent(
   websiteContent: string,
   extractedServices: string[]
 ): Promise<AnalysisResult> {
-  const prompt = `あなたは手作業代行サービスの営業担当です。以下の企業のHP内容を分析し、手作業（検品、梱包、仕分け、封入、組立など）を外注するニーズがあるかを判定してください。
+  const prompt = `あなたは手作業代行サービスの営業担当です。以下の企業のHP内容を分析し、2つの観点から評価してください。
 
 企業名: ${companyName}
 業種: ${businessType}
@@ -74,19 +76,37 @@ ${websiteContent.substring(0, 4000)}
 
 以下の形式でJSONを返してください：
 {
-  "score": 0-100の数値（手作業外注ニーズの可能性スコア）,
+  "score": 0-100の数値（外注ニーズスコア：手作業を外注したいニーズの可能性）,
+  "partnerScore": 0-100の数値（パートナーニーズスコア：繁忙期・大量案件時の外注パートナーとしてのニーズ）,
+  "companyType": "outsource" | "partner" | "unknown"（企業タイプの分類）,
   "reason": "判定理由の説明（HP内容から読み取れた具体的な根拠を含める）",
   "manualWorkPotential": "想定される手作業の種類（HP内容から特定できた具体的な作業）",
-  "recommendedApproach": "アプローチ方法の提案（企業の特性に合わせた具体的な提案）"
+  "recommendedApproach": "アプローチ方法の提案（企業タイプに合わせた具体的な提案）"
 }
 
-判定基準：
+【外注ニーズスコア（score）の判定基準】
 - HPに物流・倉庫・配送に関する記載がある：検品・梱包・仕分けニーズが高い
 - 製品の製造・加工を行っている：組立・検品ニーズがある可能性
 - ECサイトや通販事業を運営：梱包・発送ニーズが高い
 - 食品を扱っている：パッケージング・仕分けニーズがある可能性
 - 印刷・DM事業：封入・発送作業ニーズが高い
 - 人手不足・繁忙期に関する記載：外注ニーズが高い可能性
+
+【パートナーニーズスコア（partnerScore）の判定基準】
+- 自社で手作業サービスを提供している企業：業界理解があり、品質要求も明確
+- 物流センター・倉庫を運営：繁忙期のキャパ補完ニーズあり
+- DM発送・EC物流代行を行っている：大量案件時のパートナーニーズあり
+- 自社一貫体制を強調：キャパ超過時に外注パートナーを探す可能性
+- 複数拠点・大規模運営：協力会社ネットワークを持つ可能性
+
+【企業タイプ（companyType）の分類】
+- "outsource": 手作業を外注したい企業（メーカー、小売、オフィス系など）
+- "partner": 手作業を自社で行っており、繁忙期にパートナーが必要な企業（物流会社、代行業者など）
+- "unknown": 判断が難しい場合
+
+【recommendedApproachの書き分け】
+- outsource企業: 「手作業をお任せください」「コスト削減・品質向上」の提案
+- partner企業: 「繁忙期のキャパ補完パートナー」「協力会社として」の提案
 
 JSONのみを返してください。`;
 

--- a/supabase/migrations/002_add_partner_score.sql
+++ b/supabase/migrations/002_add_partner_score.sql
@@ -1,0 +1,7 @@
+-- パートナースコアと企業タイプカラムを追加
+ALTER TABLE companies ADD COLUMN IF NOT EXISTS partner_score INTEGER;
+ALTER TABLE companies ADD COLUMN IF NOT EXISTS company_type TEXT CHECK (company_type IN ('outsource', 'partner', 'unknown'));
+
+-- インデックス追加
+CREATE INDEX IF NOT EXISTS idx_companies_partner_score ON companies(partner_score);
+CREATE INDEX IF NOT EXISTS idx_companies_company_type ON companies(company_type);

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -15,6 +15,8 @@ CREATE TABLE IF NOT EXISTS companies (
   search_area TEXT,
   ai_score INTEGER,
   ai_reason TEXT,
+  partner_score INTEGER,
+  company_type TEXT CHECK (company_type IN ('outsource', 'partner', 'unknown')),
   status TEXT DEFAULT 'pending' CHECK (status IN ('pending', 'scraped', 'emailed')),
   created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
   updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()

--- a/types/index.ts
+++ b/types/index.ts
@@ -1,3 +1,5 @@
+export type CompanyType = 'outsource' | 'partner' | 'unknown';
+
 export interface Company {
   id: string;
   place_id: string | null;
@@ -11,6 +13,8 @@ export interface Company {
   search_area: string | null;
   ai_score: number | null;
   ai_reason: string | null;
+  partner_score: number | null;
+  company_type: CompanyType | null;
   status: 'pending' | 'scraped' | 'emailed';
   created_at: string;
   updated_at: string;
@@ -53,6 +57,8 @@ export interface SearchParams {
 
 export interface AnalysisResult {
   score: number;
+  partnerScore: number;
+  companyType: CompanyType;
   reason: string;
   manualWorkPotential: string;
   recommendedApproach: string;


### PR DESCRIPTION
## Summary
- **外注ニーズスコア**に加え、**パートナーニーズスコア**を追加
- **企業タイプ分類**（外注検討企業/パートナー候補/未分類）を追加
- 手作業を自社で行う企業も「繁忙期のキャパ補完パートナー」として評価

## 変更内容
- Claude分析プロンプトを2軸評価に対応
- DBに `partner_score`, `company_type` カラムを追加
- 詳細ページ、企業カード、テーブルで両スコアと企業タイプを表示

## Test plan
- [ ] Supabaseでマイグレーション実行（`002_add_partner_score.sql`）
- [ ] HP分析を実行し、パートナースコアと企業タイプが表示されることを確認
- [ ] 手作業を自社で行う企業がパートナー候補として高スコアになることを確認

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)